### PR TITLE
Support `meta` argument  for Slot

### DIFF
--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -19,7 +19,8 @@ type SlotCache = Root[];
 
 export type DataTableSlot =
 	| ((data: any, row: any) => React.JSX.Element)
-	| ((data: any, type: string, row: any) => any);
+	| ((data: any, type: string, row: any) => any)
+	| ((data: any, type: string, row: any, meta: object) => any);
 
 export type DataTableSlots = {
 	[key: string | number]: DataTableSlot;
@@ -252,8 +253,12 @@ function applySlots(cache: SlotCache, options: DTConfig, slots: DataTableSlots) 
  * @returns Rendering function
  */
 function slotRenderer(cache: SlotCache, slot: DataTableSlot) {
-	return function (data: any, type: string, row: any) {
-		if (slot.length === 3) {
+	return function (data: any, type: string, row: any, meta: object) {
+	        if (slot.length === 4) {
+			let result = slot(data, type, row, meta);
+			
+			return result['$$typeof'] ? renderJsx(cache, result) : result;
+		} else if (slot.length === 3) {
 			// The function takes three parameters so it allows for
 			// orthogonal data - not possible to cache the response
 			let result = slot(data, type, row);


### PR DESCRIPTION
feel free to include this under MIT.

As I mentioned in the forum [discussion ](https://datatables.net/forums/discussion/80135)that I want to access the `meta.row` value.

This PR allows me to apply styles to the clicked row by accessing `meta` argument. 
